### PR TITLE
use gulp to compile sass

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1,0 +1,75 @@
+.mask {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  width: 0%;
+  height: 0%;
+  background: rgba(0, 0, 0, 0.4); }
+
+.mask--hidden {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  -webkit-transition: opacity 0.3s, height 0 0.3s, width 0 0.3s;
+  -moz-transition: opacity 0.3s, height 0 0.3s, width 0 0.3s;
+  -ms-transition: opacity 0.3s, height 0 0.3s, width 0 0.3s;
+  -o-transition: opacity 0.3s, height 0 0.3s, width 0 0.3s;
+  transition: opacity 0.3s, height 0 0.3s, width 0 0.3s; }
+
+.mask--revealed {
+  opacity: 1;
+  width: 100%;
+  height: 100%;
+  -webkit-transition: opacity 0.3s;
+  -moz-transition: opacity 0.3s;
+  -ms-transition: opacity 0.3s;
+  -o-transition: opacity 0.3s;
+  transition: opacity 0.3s; }
+
+.sheet {
+  height: 100%;
+  z-index: 1001;
+  background: #FCFBF0;
+  position: fixed;
+  width: 25%;
+  top: 0;
+  right: 0;
+  -webkit-transition: right 0.3s;
+  -moz-transition: right 0.3s;
+  -ms-transition: right 0.3s;
+  -o-transition: right 0.3s;
+  transition: right 0.3s; }
+
+.sheet--big {
+  width: 80%; }
+
+.sheet--med {
+  width: 50%; }
+
+.sheet--small {
+  width: 25%; }
+
+.sheet--hidden {
+  right: -100%; }
+
+.sheet--revealed {
+  right: 0; }
+
+.sheet__restrict-y {
+  height: 100%;
+  overflow-y: auto; }
+
+.sheet__restrict-x {
+  width: 100%;
+  overflow-x: hidden; }
+
+.sheet__close {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  left: -40px;
+  top: 0; }
+
+body.clipped {
+  overflow: hidden; }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,10 @@
+var gulp = require('gulp');
+var sass = require('gulp-sass');
+
+gulp.task('default', ['sass']);
+
+gulp.task('sass', function() {
+  return gulp.src(['styles/sass/*.scss'])
+    .pipe(sass())
+    .pipe(gulp.dest('dist/'));
+});

--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
     "name": "Jonathan Bowers",
     "email": "jonotron@gmail.com"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "gulp": "^3.8.11",
+    "gulp-sass": "^1.3.3"
+  }
 }


### PR DESCRIPTION
use `gulp sass` (default, so just `gulp` also works) to compile sass into css for easy inclusion in non sass projects
