### PR TITLE
Fixes background content scrolling when it's height was more than 100%

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -64,4 +64,7 @@
   top: 0; }
 
 body.jbas-clipped {
-  overflow: hidden; }
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+  position: fixed; }

--- a/styles/sass/_sheet.scss
+++ b/styles/sass/_sheet.scss
@@ -46,5 +46,8 @@
 }
 
 body.jbas-clipped {
-  overflow: hidden
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+  position: fixed;
 }


### PR DESCRIPTION
In Safari on Mac OS X and iOS, if the content in the background had a height greater than 100%, it would scroll behind the action sheet.

This fixes the body with a set height and width and prevents scrolling.
