### PR TITLE
Remove position fixed so the viewport doesn't jump

### DIFF
--- a/styles/sass/_pane.scss
+++ b/styles/sass/_pane.scss
@@ -49,5 +49,4 @@ body.jbsp-clipped {
   overflow: hidden;
   height: 100%;
   width: 100%;
-  position: fixed;
 }


### PR DESCRIPTION
This fixes a bug in chrome where the viewport will "jump" to the top of the page when a slidey-pane is opened. This is because `position: fixed` is set, so this PR removes it.

Note that adding this feature appears to break the scroll block on Safari on iOS, which allows the mobile user to scroll the background page.
